### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -28,13 +28,10 @@ func teamResource(team client.Team) *v2.Resource {
 		team.Name,
 		teamResourceType,
 		team.Sys.ID,
-		[]rs.GroupTraitOption{
-			rs.WithGroupProfile(
-				map[string]interface{}{
-					"description": team.Description,
-				},
-			),
-		},
+		[]rs.GroupTraitOption{},
+		rs.WithResourceProfile(map[string]interface{}{
+			"description": team.Description,
+		}),
 	)
 	if err != nil {
 		return nil

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -32,8 +32,6 @@ func (o *userBuilder) userResource(ctx context.Context, user client.User) *v2.Re
 
 	traits := []rs.UserTraitOption{
 		rs.WithEmail(user.Email, true),
-		rs.WithUserProfile(profile),
-		rs.WithCreatedAt(user.Sys.CreatedAt),
 	}
 
 	lastActive := o.client.GetLastActiveAt(ctx, user.Sys.ID)
@@ -46,6 +44,8 @@ func (o *userBuilder) userResource(ctx context.Context, user client.User) *v2.Re
 		userResourceType,
 		user.Sys.ID,
 		traits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceCreatedAt(user.Sys.CreatedAt),
 	)
 	if err != nil {
 		return nil


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
